### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786527240,
+        "narHash": "sha256-OLtJPnSXcRy79Rf7BhYaMeXAVF625FpLcd3+Svq641Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e0c84f9d0ad137f076dc957494f5b39885597d4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "A Flake providing everything needed to run hamr";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin"; # last branch to suppport Intel macOS
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+            system = system;
+          }
+        );
+    in
+    {
+      packages = forAllSystems (
+        {
+          pkgs,
+          system,
+        }:
+        {
+          hamr = pkgs.callPackage ./package.nix { };
+          default = self.packages.${system}.hamr;
+        }
+      );
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  nodejs,
+}:
+stdenvNoCC.mkDerivation {
+  name = "hamr";
+
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/lib
+    cp alphabets.js compress.js standalone.js $out/lib
+    makeWrapper ${lib.getExe nodejs} $out/bin/hamr \
+      --add-flags "$out/lib/standalone.js"
+    runHook preInstall
+  '';
+
+  meta = {
+    description = "Static URL compressor and QR code optimizer";
+    homepage = "https://github.com/p2r3/ha.mr";
+    mainProgram = "hamr";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
This PR adds `flake.nix` and `package.nix` files, allowing the Nix package manager to execute the standalone ha.mr directly from this repository.

The flake uses the Nixpkgs 26.05 stable branch, as it is the last one to officially support Intel macOS. Once that branch goes EOL, Intel macOS will as well, and support can be removed by bumping to either 26.11 or unstable. The version will be locked using the `flake.lock` file regardless.
The package wraps `standalone.js` using the latest NodeJS from Nixpkgs.
I have verified it to work, and will also submit the package to the standard Nixpkgs repository.
Having a flake.nix file makes the support more discoverable, and alllows users to execute (hypothetical) in-development versions.
