### PR TITLE
Add Copy Output Button

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@
       color: gray;
       user-select: none;
     }
+    #copy-button {
+      margin: 4px 0 0 0;
+    }
     #qrcode {
       display: none;
     }
@@ -142,6 +145,7 @@
       <a id="output-link" target="_blank">Enter a link above to compress</a>
       <br><span id="output-ratio">&nbsp;</span>
     </p>
+    <button id="copy-button" disabled>Copy Output</button>
 
     <image width="256" height="256" id="qrcode"></image>
 

--- a/main.js
+++ b/main.js
@@ -38,6 +38,7 @@ const inputLinkElement = document.querySelector("#input-link");
 const outputLinkElement = document.querySelector("#output-link");
 const outputRatioElement = document.querySelector("#output-ratio");
 const queryWarningElement = document.querySelector("#query-warning");
+const copyButtonElement = document.querySelector("#copy-button")
 
 const qrCodeImage = document.querySelector("#qrcode");
 const qrCodeCorrectionLevelContainer = document.querySelector("#qr-correct-level-container");
@@ -105,6 +106,7 @@ function updateOutput () {
       qrCodeImage.style.display = "none";
       qrCodeCorrectionLevelContainer.style.display = "none";
     }
+    setCopyButtonState(input)
   } catch (e) {
     if (!input.trim()) {
       outputLinkElement.textContent = "Enter a link above to compress";
@@ -118,9 +120,34 @@ function updateOutput () {
     outputRatioElement.style.color = "rgba(255, 255, 255, 0)";
     outputLinkElement.removeAttribute("href");
     queryWarningElement.style.display = "none";
+    setCopyButtonState(input)
   }
 }
 inputLinkElement.addEventListener("input", updateOutput);
+
+function copyButtonClickHandler () {
+  const input = inputLinkElement.value.trim();
+
+  if (input) {
+    navigator.clipboard.writeText(outputLinkElement.textContent);
+  
+    setCopyButtonText("Copied!")
+    setTimeout(() => {setCopyButtonText("Copy Output")}, 2000)
+  }
+}
+copyButtonElement.addEventListener("click", copyButtonClickHandler)
+
+function setCopyButtonText(text) {
+  const buttonTexts = new Set(["Copy Output", "Copied!"]);
+
+  if (buttonTexts.has(text)) {
+    copyButtonElement.textContent = text;
+  }
+}
+
+function setCopyButtonState(input) {
+  copyButtonElement.disabled = !input ? true : false;
+}
 
 (() => {
   let payload = null;


### PR DESCRIPTION
Adds ""Copy Output" button for users to quickly copy the URL output to their device clipboard.

- Tested with keyboard controls,
- Button text updates for 2 seconds to inform the user their text has been copied, then reverts back to its default state.
- Button is disabled when there is no text input.

### Images
<div style="display:flex; flex-direction: row; flex-wrap: wrap;">
<img width="280" height="288" alt="image" src="https://github.com/user-attachments/assets/d79faa68-ba09-4e26-bd23-f961decced2e" />
<img width="330" height="288" alt="image" src="https://github.com/user-attachments/assets/a6475791-f877-4681-b024-6347320ffeb1" />
<img width="330" height="288" alt="image" src="https://github.com/user-attachments/assets/ac1110ec-93e5-4c2b-beda-105c531600b2" />
</div>

