### PR TITLE
pad decoded percent escapes to two hex digits

### DIFF
--- a/compress.js
+++ b/compress.js
@@ -486,7 +486,7 @@ export function decompress (input, alphabet) {
         path += digit;
         if (digit === "%") {
           const byte = number % 256n;
-          path += byte.toString(16);
+          path += byte.toString(16).padStart(2, "0");
           number /= 256n;
         }
       }


### PR DESCRIPTION
`decompress()` emits %-escaped bytes with `byte.toString(16)`, therefore bytes below 0x10 produce a single hex digit and swallow the following character into the escape:

```
https://example.com/a%0Ab  ->  https://example.com/a%ab
```

this is fixed by padding to two digits, after which it becomes

```
https://example.com/a%0Ab  ->  https://example.com/a%0ab
https://example.com/x%01y  ->  https://example.com/x%01y
```
