### PR TITLE
Add Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY index.html 404.html /usr/share/nginx/html/
+COPY alphabets.js compress.js main.js qrcode.js standalone.js /usr/share/nginx/html/

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,5 @@
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  server_name localhost;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /404.html;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Dockerfile that serves the static site with nginx:alpine (only HTML/JS assets copied in)
- Add compose.yml so `docker compose up --build` starts the app on port 8080
- Add nginx.conf with `try_files` fallback to 404.html so path-based QR URLs match GitHub Pages behavior

## Test plan
- [X] `docker compose up --build`
- [X] Open http://localhost:8080 and confirm the compressor UI loads
- [X] Open a missing path (e.g. http://localhost:8080/SOMEFAKEPATH) and confirm the app still loads via 404.html
- [X] Compress a link with QR output enabled and verify path-style local URLs still work