### PR TITLE
fix: respect system color scheme for dark mode

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,6 +6,11 @@
   <title>ha.mr - link compressor</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Hammersmith+One&display=swap');
+
+    :root {
+      color-scheme: light dark;
+    }
+
     html, body {
       margin: 0;
       width: 100%;
@@ -78,7 +83,6 @@
       border-radius: 10px;
       margin: 10px 0;
       font-size: 16px;
-      background-color: rgb(230, 230, 230);
     }
     #output-link-container {
       margin: 10px 0 0 0;

--- a/404.html
+++ b/404.html
@@ -79,10 +79,17 @@
       padding: 5px 8px;
       border: 0;
       outline: 0;
-      border-bottom: 2px solid darkgray;
+      border-bottom: 2px solid light-dark(
+        rgba(0, 0, 0, 0.2),
+        rgba(255, 255, 255, 0.2)
+      );
       border-radius: 10px;
       margin: 10px 0;
       font-size: 16px;
+      background-color: light-dark(
+        rgba(0, 0, 0, 0.1),
+        rgba(255, 255, 255, 0.1)
+      );
     }
     #output-link-container {
       margin: 10px 0 0 0;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
   <title>ha.mr - link compressor</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Hammersmith+One&display=swap');
+
+    :root {
+      color-scheme: light dark;
+    }
+
     html, body {
       margin: 0;
       width: 100%;
@@ -78,7 +83,6 @@
       border-radius: 10px;
       margin: 10px 0;
       font-size: 16px;
-      background-color: rgb(230, 230, 230);
     }
     #output-link-container {
       margin: 10px 0 0 0;

--- a/index.html
+++ b/index.html
@@ -79,10 +79,17 @@
       padding: 5px 8px;
       border: 0;
       outline: 0;
-      border-bottom: 2px solid darkgray;
+      border-bottom: 2px solid light-dark(
+        rgba(0, 0, 0, 0.2),
+        rgba(255, 255, 255, 0.2)
+      );
       border-radius: 10px;
       margin: 10px 0;
       font-size: 16px;
+      background-color: light-dark(
+        rgba(0, 0, 0, 0.1),
+        rgba(255, 255, 255, 0.1)
+      );
     }
     #output-link-container {
       margin: 10px 0 0 0;


### PR DESCRIPTION
## Summary

Adds dark mode support that follows the user's system color scheme.

## Changes

* enables light and dark color schemes using `color-scheme`
* removes the hardcoded input background so the textbox adapts correctly
* applies the same changes to both `index.html` and `404.html`

## Testing

Tested manually in both light and dark system themes, including:

* input field readability
* output text
* QR code display
* checkboxes and slider controls

Closes #42 