### PR TITLE
feat: optimize default QR error correction

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,7 +42,41 @@ const queryWarningElement = document.querySelector("#query-warning");
 const qrCodeImage = document.querySelector("#qrcode");
 const qrCodeCorrectionLevelContainer = document.querySelector("#qr-correct-level-container");
 const qrCodeCorrectionLevelElement = document.querySelector("#qr-correct-level");
-qrCodeCorrectionLevelElement.addEventListener("change", updateOutput);
+
+let qrCorrectionManuallySet = false;
+
+qrCodeCorrectionLevelElement.addEventListener("change", () => {
+  qrCorrectionManuallySet = true;
+  updateOutput();
+});
+
+function getOptimalErrorCorrectionLevel (text) {
+  const levels = ["M", "Q", "H"];
+
+  const baseVersion = QRCode.create(text, {
+    errorCorrectionLevel: levels[0]
+  }).version;
+
+  let optimalLevel = levels[0];
+
+  for (const level of levels.slice(1)) {
+    try {
+      const candidate = QRCode.create(text, {
+        errorCorrectionLevel: level
+      });
+
+      if (candidate.version > baseVersion) {
+        break;
+      }
+
+      optimalLevel = level;
+    } catch {
+      break;
+    }
+  }
+
+  return optimalLevel;
+}
 
 function updateOutput () {
   const input = inputLinkElement.value.trim();
@@ -86,10 +120,21 @@ function updateOutput () {
     outputLinkElement.href = `http://ha.mr#${output}`;
     outputLinkElement.style.color = "";
     if (settings.qr) {
-      const errorCorrection = ["L", "M", "Q", "H"][qrCodeCorrectionLevelElement.value];
+      const correctionLevels = ["L", "M", "Q", "H"];
+
       qrCodeImage.style.display = "inline";
       qrCodeCorrectionLevelContainer.style.display = "inline";
-      let qrCodeLink = `HTTP://HA.MR/${compress(input, outputAlphabetQR)}`;
+
+      const qrCodeLink = `HTTP://HA.MR/${compress(input, outputAlphabetQR)}`;
+
+      if (!qrCorrectionManuallySet) {
+        const optimalLevel = getOptimalErrorCorrectionLevel(qrCodeLink);
+        qrCodeCorrectionLevelElement.value = correctionLevels.indexOf(optimalLevel);
+      }
+
+      const errorCorrection =
+        correctionLevels[qrCodeCorrectionLevelElement.value];
+
       QRCode.toDataURL(qrCodeLink, {
         errorCorrectionLevel: errorCorrection,
         scale: 8
@@ -121,7 +166,11 @@ function updateOutput () {
     queryWarningElement.style.display = "none";
   }
 }
-inputLinkElement.addEventListener("input", updateOutput);
+
+inputLinkElement.addEventListener("input", () => {
+  qrCorrectionManuallySet = false;
+  updateOutput();
+});
 
 (() => {
   let payload = null;


### PR DESCRIPTION
## Summary

Automatically selects the highest default QR error correction level that does not increase the resulting QR code size.

## Changes

- uses the current M correction level as the baseline
- checks Q and H using `QRCode.create()` before rendering
- selects the highest level that keeps the same QR version
- stops checking once a higher correction level requires a larger QR code
- preserves the existing correction-level slider for manual overrides
- recalculates the optimal default when the input URL changes

## Testing

Tested manually with multiple URL lengths and verified that:

- the highest correction level with the baseline QR version is selected
- levels that increase the QR version are not selected automatically
- only the final QR code is rendered
- manual slider selections are respected
- changing the input recalculates the smart default
- invalid input behavior remains unchanged

Also ran:

- `git diff --check`

Closes #3 