### PR TITLE
fix: preserve percent-encoded reserved path characters

### DIFF
--- a/compress.js
+++ b/compress.js
@@ -212,9 +212,18 @@ export function compress (input, alphabet) {
     pathSegments.push({ type: "hash", value: url.hash.slice(1) });
   }
 
-  // Normalize path segment encoding
+  // Normalize path segment encoding while preserving escaped reserved characters
+  const reservedEscape = /(%(?:23|24|26|2B|2C|2F|3A|3B|3D|3F|40))/gi;
+
   for (const segment of pathSegments) {
-    segment.value = encodeURI(decodeURI(segment.value));
+    segment.value = segment.value
+      .split(reservedEscape)
+      .map((part, index) =>
+        index % 2 === 1
+          ? part
+          : encodeURI(decodeURI(part))
+      )
+      .join("");
   }
 
   // Encode path following domain segment-by-segment, using best algorithm for each


### PR DESCRIPTION
## Summary

Fixes double-encoding of percent-encoded reserved characters in URL path segments.

Closes #58.

The issue was caused by the path normalization step applying:

```js
encodeURI(decodeURI(segment.value))
```

to every segment.

This works for many ordinary encoded characters, but it behaves differently for characters that `decodeURI()` intentionally treats as URI-reserved.

## Root cause

For reserved characters such as:

```text
%26  &
%2F  /
%3F  ?
%23  #
```

`decodeURI()` preserves the escape instead of decoding it.

For example:

```js
decodeURI("foo%26bar")
// "foo%26bar"
```

The following `encodeURI()` call then sees the literal `%` and encodes it again:

```js
encodeURI("foo%26bar")
// "foo%2526bar"
```

As a result, a URL such as:

```text
https://example.com/foo%26bar
```

could be decompressed as:

```text
https://example.com/foo%2526bar
```

The same behavior affected other reserved escapes as well.

## Changes

The normalization step now preserves percent-encoded reserved characters before applying the existing `decodeURI()` / `encodeURI()` normalization to the rest of the segment.

The preserved escape set covers:

```text
%23  #
%24  $
%26  &
%2B  +
%2C  ,
%2F  /
%3A  :
%3B  ;
%3D  =
%3F  ?
%40  @
```

This keeps the existing normalization behavior for non-reserved escapes while preventing reserved ones from being encoded a second time.

## Why not use `decodeURIComponent()`?

A simpler-looking alternative would be:

```js
encodeURIComponent(decodeURIComponent(segment.value))
```

but that would change the semantics of encoded reserved characters.

For example:

```text
%2F
```

represents an encoded `/` inside a path segment.

Decoding it before compression could turn it into a real path separator and therefore change the structure of the URL rather than simply normalize its representation.

The fix therefore keeps the existing URI-level normalization behavior and only protects the escapes that must remain encoded.

## Validation

Tested direct `compress()` → `decompress()` round trips for the following inputs:

```text
https://example.com/foo%26bar
https://example.com/foo%2Fbar
https://example.com/foo%3Fbar
https://example.com/foo%23bar
https://example.com/foo%20bar
https://example.com/foo%25bar
https://example.com/foo%2526bar
https://example.com/foo%7Ebar
```

Observed results:

```text
%26   -> %26
%2F   -> %2f
%3F   -> %3f
%23   -> %23
%20   -> %20
%25   -> %25
%2526 -> %2526
%7E   -> ~
```

The lowercase hex digits in `%2f` and `%3f` are equivalent percent escapes and come from the existing decoder behavior.

The `%7E` -> `~` normalization is also preserved from the existing implementation.

Additionally:

```text
git diff --check
```

passes.

## Scope

This change is limited to path segment normalization and does not alter:

* the compression format version
* hostname encoding
* domain/TLD handling
* query/hash segment encoding structure
* Huffman tables
* output alphabets
* existing percent-byte decoding logic
