### PR TITLE
fix: preserve docs module paths in Nix package

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -13,8 +13,9 @@ stdenvNoCC.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin $out/lib
-    cp docs/alphabets.js docs/compress.js standalone.js $out/lib
+    mkdir -p $out/bin $out/lib/docs
+    cp docs/alphabets.js docs/compress.js $out/lib/docs
+    cp standalone.js $out/lib
     makeWrapper ${lib.getExe nodejs} $out/bin/hamr \
       --add-flags "$out/lib/standalone.js"
     runHook preInstall


### PR DESCRIPTION
Closes #62

## Summary

Fixes the Nix package layout so the installed `standalone.js` can resolve its codec modules correctly.

The CLI currently imports:

```js
./docs/compress.js
./docs/alphabets.js
```

but the Nix package was installing those files directly into `$out/lib`, which caused the built CLI to fail at runtime with `ERR_MODULE_NOT_FOUND`.

## Changes

* create `$out/lib/docs`
* install `compress.js` and `alphabets.js` under `$out/lib/docs`
* keep `standalone.js` in `$out/lib`

This preserves the directory structure expected by the existing imports without changing the standalone code itself.

## Validation

Tested from a fresh Linux/WSL clone.

Before the fix:

```bash
nix build
./result/bin/hamr https://example.com
```

resulted in:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../hamr/lib/docs/compress.js'
```

After the fix:

```bash
nix build
./result/bin/hamr https://example.com
```

outputs:

```text
http://ha.mr#~Uk6
```

and decoding the same URL:

```bash
./result/bin/hamr "http://ha.mr#~Uk6"
```

outputs:

```text
https://example.com
```