### PR TITLE
css: widen the width of the input link box

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -99,6 +99,7 @@
       font-size: 0.75em;
     }
     #input-link {
+      min-width: 50vw;
       padding: 5px 8px;
       border: 0;
       outline: 0;
@@ -109,6 +110,7 @@
       border-radius: 10px;
       margin: 10px 0;
       font-size: 16px;
+      text-align: center;
       background-color: light-dark(
         rgba(0, 0, 0, 0.1),
         rgba(255, 255, 255, 0.1)


### PR DESCRIPTION
Often when using this tool people may paste in long links that - as your tool already warns about - may need to have some parameters etc removed, however the input link box is quite small - especially on wider screens.

This may limit people's ability to edit the link properly.

To this end, this PR does 2 things:
1. widens the input box to be a minimum fo 50% of the display width
2. centres the text displayed, just like the output link, for consistency and reduced mouse movements.

Tested by making the same changes in the browser dev tools.

> [!NOTE]
> AI statement: no AI was used in this PR.