### PR TITLE
fix: nginx conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,9 +2,9 @@ server {
   listen 80;
   server_name localhost;
   root /usr/share/nginx/html;
-  index docs/404.html;
+  index 404.html;
 
   location / {
-    try_files $uri $uri/ /docs/404.html;
+    try_files $uri $uri/ /404.html;
   }
 }


### PR DESCRIPTION
fixing a bug introduced in c6635657bed53ccac42c8af17105a58d2b4af807. Was getting 403 forbidden because it was trying to find in /docs while Dockerfile copy at root