### PR TITLE
Reject nonhttp(s) and URL credentials

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -63,6 +63,20 @@ function updateOutput () {
   try {
     const alphabet = settings.emoji ? outputAlphabetEmoji : outputAlphabetASCII;
     const output = compress(input, alphabet);
+
+    // compress.js does not have support for non-http(s) protocols, nor credentials.
+    // previously it would silently strip them, but this block makes it reject instead
+    // additionally, invalid inputs the compressor would otherwise accept (like "http://") are rejected as well
+    const url = new URL(input);
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error(`Invalid protocol: ${url.protocol}. Only http and https are supported.`);
+    }
+
+    if (url.username || url.password) {
+      throw new Error(`Credentials in URL are not supported`);
+    }
+
     let inputNormalized = input;
     const inputLower = input.toLowerCase();
     if (inputLower.startsWith("https://")) {


### PR DESCRIPTION
Closes #71 

This PR makes the frontend reject any invalid urls, nonhttp(s) schemes, or credentials in the URL upfront instead of letting the compressor silently strip them and cause confusion.

![](https://transfur.science/ob0ynqck)

<details>
<summary><s>Old contents superseded by redesign</s></summary>
Unsupported url parts would be silently discarded, leading to a situation where a user might make a link and be confused about why parts are missing and/or the link doesn't work as expected. This PR implements a simple check to let them know what was discarded and why.

![](https://transfur.science/0t1toh6f)

Please give me input about the text, I'm open to changing it but this is my best effort for explaining without being overly technical.
</details>