### PR TITLE
Fix overflow of long links on mobile viewports (+hotfix)

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -155,6 +155,11 @@
       opacity: 0;
       transition: opacity 1s;
     }
+    #redirect-container p {
+      word-break: break-word;
+      text-align: center;
+      padding: 0 8px;
+    }
   </style>
 </head>
 <body>

--- a/docs/main.js
+++ b/docs/main.js
@@ -67,7 +67,11 @@ function updateOutput () {
     // compress.js does not have support for non-http(s) protocols, nor credentials.
     // previously it would silently strip them, but this block makes it reject instead
     // additionally, invalid inputs the compressor would otherwise accept (like "http://") are rejected as well
-    const url = new URL(input);
+
+    // Regex: one or more word [a-zA-Z0-9_] characters, followed by ://. 
+    // Underscore is not valid but will get rejected by new URL() anyway
+    const hasProtocol = input.match(/\w+:\/\//); 
+    const url = new URL(hasProtocol ? input : "http://" + input);
 
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new Error(`Invalid protocol: ${url.protocol}. Only http and https are supported.`);


### PR DESCRIPTION
I dont think I could make more verbose explanation. Fixes #73 

![](https://transfur.science/93s9g61d)

Also a hotfix for #72 not accounting links entered without any protocol before them.
![](https://transfur.science/mn1sfl4m)